### PR TITLE
Improve docker image versioning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,14 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: quay.io/onecause/efs-provisioner
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !github.event.release.prerelease }}
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ !github.event.release.prerelease }}
+            type=semver,pattern={{major}},enable=${{ !github.event.release.prerelease }}
+            type=semver,pattern=v{{major}},enable=${{ !github.event.release.prerelease }}
+            type=semver,value=latest,enable=${{ !github.event.release.prerelease }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Quay.io


### PR DESCRIPTION
- Adds a `<version>` Docker tag for any GitHub release with a `v<semver>`-based tag
- Adds/moves the `<major>.<minor>` Docker tag when a non-prerelease semver release is created
- Adds/moves the `<major>` Docker tag when a non-prerelease semver release is created
- Adds/moves the `latest` Docker tag when a non-prerelease semver release is created
- Creates `v<tag>` Docker tags of all of the above for backwards compatibility